### PR TITLE
Add automated check for docs.lakeFS.io going stale

### DIFF
--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -1,0 +1,48 @@
+name: Docs - Check docs.lakefs.io matches source
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build-and-compare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Docs source
+        uses: actions/checkout@v3
+        with:
+          repository: treeverse/lakeFS
+          path: lakeFS
+
+      - name: Checkout Published Docs
+        uses: actions/checkout@v2
+        with:
+          repository: treeverse/docs-lakeFS
+          path: docs-lakeFS
+
+      - name: Setup Ruby    
+        uses: ruby/setup-ruby@v1
+        with:
+          working-directory: lakeFS/docs
+          ruby-version: '2.7'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Build Docs from Source    
+        working-directory: lakeFS/docs
+        run: bundle exec jekyll build --config _config.yml 
+  
+      - name: Compare Generated Site
+        run: |
+          diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
+                  grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
+                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" > diffs.txt
+          diffs=$(wc -l < diffs.txt | tr -d '[:space:]')
+          if [ "$diffs" -ne 0 ]; then
+            echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
+            echo " "
+            cat diffs.txt
+            exit 1
+          fi


### PR DESCRIPTION
### Linked Issue

Closes https://github.com/treeverse/lakeFS/issues/5484

---

## Change Description

### Background

If a docs page is deleted and no redirect setup, the original page remains on docs.lakeFS.io. This means that users will view stale content. 
      
### New Feature

This will check once a day that the docs.lakeFS.io files match those that are generated by a build of the docs source on the master branch

### Testing Details

Tested here https://github.com/rmoff/lakeFS/actions/runs/5267873714/jobs/9523718477

### Breaking Change?

No
