### PR TITLE
Store any documents that are mismatched between docs.lakefs.io and the source docs repo

### DIFF
--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -46,9 +46,8 @@ jobs:
                           -e "Files docs-lakeFS/posts/index.html and lakeFS/docs/_site/posts/index.html differ" \
                           -e "Files docs-lakeFS/redirects.json and lakeFS/docs/_site/redirects.json differ" \
                         > /tmp/diffs.txt
-          diff_ct=$(wc -l < /tmp/diffs.txt | tr -d '[:space:]')
 
-          if [ "$diff_ct" -ne 0 ]; then
+          if [ -e "/tmp/diffs.txt" ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
             echo " "
             cat /tmp/diffs.txt
@@ -65,7 +64,6 @@ jobs:
             exit 1
           else
             echo "✅ Docs match"
-            true
           fi
 
       - name: Upload artifacts if mismatches found

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -44,7 +44,7 @@ jobs:
           pwd
           grep -v -e "docs-lakeFS/assets/js/search-data.json" \
                   -e "docs-lakeFS/posts/index.html" \
-                  -e "docs-lakeFS/redirects.json" /tmp/diffs0.txt > /tmp/diffs.txt
+                  -e "docs-lakeFS/redirects.json" /tmp/diffs0.txt > /tmp/diffs.txt || true
           pwd
 
           if [ -e "/tmp/diffs.txt" ]; then

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -45,9 +45,8 @@ jobs:
                           -e "docs-lakeFS/assets/js/search-data.json" \
                           -e "docs-lakeFS/posts/index.html" \
                           -e "docs-lakeFS/redirects.json" > /tmp/diffs.txt || true
-          ls -l /tmp/
-          [ -e "/tmp/diffs.txt" ]
-          if [ -e "/tmp/diffs.txt" ]; then
+
+          if [ -s "/tmp/diffs.txt" ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
             echo " "
             cat /tmp/diffs.txt

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -39,9 +39,16 @@ jobs:
         run: |
           diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
                   grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
-                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" > diffs.txt
-          diffs=$(wc -l < diffs.txt | tr -d '[:space:]')
-          if [ "$diffs" -ne 0 ]; then
+                  grep -v -e ": .git" \
+                          -e ": versions.json" \
+                          -e ": CNAME" \
+                          -e "Files docs-lakeFS/assets/js/search-data.json and lakeFS/docs/_site/assets/js/search-data.json differ" \
+                          -e "Files docs-lakeFS/posts/index.html and lakeFS/docs/_site/posts/index.html differ" \
+                          -e ": CNAME" \
+                        > diffs.txt
+          diff_ct=$(wc -l < diffs.txt | tr -d '[:space:]')
+
+          if [ "$diff_ct" -ne 0 ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
             echo " "
             cat diffs.txt

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -37,6 +37,7 @@ jobs:
   
       - name: Compare Generated Site
         run: |
+          pwd
           diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
                   grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
                   grep -v -e ": .git" \
@@ -47,7 +48,8 @@ jobs:
                           -e "Files docs-lakeFS/redirects.json and lakeFS/docs/_site/redirects.json differ" \
                         > /tmp/diffs.txt
 
-          ls -l /tmp/diffs.txt
+          pwd
+          ls -l /tmp/
 
           if [ -e "/tmp/diffs.txt" ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -35,18 +35,18 @@ jobs:
         working-directory: lakeFS/docs
         run: bundle exec jekyll build --config _config.yml 
   
-      - name: Compare Generated Site 1
+      - name: Compare Generated Site to live
         run: |
-          pwd
           diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
                   grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
-                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" > /tmp/diffs0.txt
-          pwd
-          grep -v -e "docs-lakeFS/assets/js/search-data.json" \
-                  -e "docs-lakeFS/posts/index.html" \
-                  -e "docs-lakeFS/redirects.json" /tmp/diffs0.txt > /tmp/diffs.txt || true
-          pwd
-
+                  grep -v -e ": .git" \
+                          -e ": versions.json" \
+                          -e ": CNAME" \
+                          -e "docs-lakeFS/assets/js/search-data.json" \
+                          -e "docs-lakeFS/posts/index.html" \
+                          -e "docs-lakeFS/redirects.json" > /tmp/diffs.txt || true
+          ls -l /tmp/
+          [ -e "/tmp/diffs.txt" ]
           if [ -e "/tmp/diffs.txt" ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
             echo " "

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -35,7 +35,20 @@ jobs:
         working-directory: lakeFS/docs
         run: bundle exec jekyll build --config _config.yml 
   
-      - name: Compare Generated Site
+      - name: Compare Generated Site 1
+        run: |
+          diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
+                  grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
+                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" > diffs.txt
+          diffs=$(wc -l < diffs.txt | tr -d '[:space:]')
+          if [ "$diffs" -ne 0 ]; then
+            echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
+            echo " "
+            cat diffs.txt
+            exit 1
+          fi
+
+      - name: Compare Generated Site 2
         run: |
           pwd
           ls -l 

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -45,13 +45,13 @@ jobs:
                           -e "Files docs-lakeFS/assets/js/search-data.json and lakeFS/docs/_site/assets/js/search-data.json differ" \
                           -e "Files docs-lakeFS/posts/index.html and lakeFS/docs/_site/posts/index.html differ" \
                           -e "Files docs-lakeFS/redirects.json and lakeFS/docs/_site/redirects.json differ" \
-                        > diffs.txt
-          diff_ct=$(wc -l < diffs.txt | tr -d '[:space:]')
+                        > /tmp/diffs.txt
+          diff_ct=$(wc -l < /tmp/diffs.txt | tr -d '[:space:]')
 
           if [ "$diff_ct" -ne 0 ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
             echo " "
-            cat diffs.txt
+            cat /tmp/diffs.txt
 
             mkdir -p /tmp/mismatched-files/docs-lakeFS 
             mkdir -p /tmp/mismatched-files/lakeFS/docs/_site
@@ -60,9 +60,12 @@ jobs:
               file2=$(echo "$line" | cut -d' ' -f4)
               cp "$file1" /tmp/mismatched-files/docs-lakeFS 
               cp "$file2" /tmp/mismatched-files/lakeFS/docs/_site
-            done < diffs.txt            
-           
+            done < /tmp/diffs.txt
+
             exit 1
+          else
+            echo "✅ Docs match"
+            true
           fi
 
       - name: Upload artifacts if mismatches found
@@ -70,4 +73,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: mismatched-files
-          path: /tmp/mismatched-files/        
+          path: |
+            /tmp/mismatched-files/
+            /tmp/diffs.txt

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -31,13 +31,20 @@ jobs:
           ruby-version: '2.7'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+      - name: pwd1
+        run: pwd
+
       - name: Build Docs from Source    
         working-directory: lakeFS/docs
         run: bundle exec jekyll build --config _config.yml 
   
+      - name: pwd2
+        run: pwd
+
       - name: Compare Generated Site
         run: |
           pwd
+          ls -l 
           diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
                   grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
                   grep -v -e ": .git" \

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: mismatched-files
+          retention-days: 5
           path: |
             /tmp/mismatched-files/
             /tmp/diffs.txt

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -3,6 +3,7 @@ name: Docs - Check docs.lakefs.io matches source
 on:
   push:
     branches: [ main ]
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -31,32 +31,26 @@ jobs:
           ruby-version: '2.7'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      - name: pwd1
-        run: pwd
-
       - name: Build Docs from Source    
         working-directory: lakeFS/docs
         run: bundle exec jekyll build --config _config.yml 
   
-      - name: pwd2
-        run: pwd
-
       - name: Compare Generated Site
         run: |
           pwd
           ls -l 
-          diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
-                  grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
-                  grep -v -e ": .git" \
-                          -e ": versions.json" \
-                          -e ": CNAME" \
-                          -e "Files docs-lakeFS/assets/js/search-data.json and lakeFS/docs/_site/assets/js/search-data.json differ" \
-                          -e "Files docs-lakeFS/posts/index.html and lakeFS/docs/_site/posts/index.html differ" \
-                          -e "Files docs-lakeFS/redirects.json and lakeFS/docs/_site/redirects.json differ" \
-                        > /tmp/diffs.txt
+          diff --brief --recursive docs-lakeFS lakeFS/docs/_site > /tmp/raw_diff.txt
+          pwd
+          grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' /tmp/raw_diff.txt | \
+          grep -v -e ": .git" \
+                  -e ": versions.json" \
+                  -e ": CNAME" \
+                  -e "Files docs-lakeFS/assets/js/search-data.json and lakeFS/docs/_site/assets/js/search-data.json differ" \
+                  -e "Files docs-lakeFS/posts/index.html and lakeFS/docs/_site/posts/index.html differ" \
+                  -e "Files docs-lakeFS/redirects.json and lakeFS/docs/_site/redirects.json differ" \
+                > /tmp/diffs.txt
 
           pwd
-          ls -l /tmp/
 
           if [ -e "/tmp/diffs.txt" ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -44,5 +44,22 @@ jobs:
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
             echo " "
             cat diffs.txt
+
+            mkdir -p /tmp/mismatched-files/docs-lakeFS 
+            mkdir -p /tmp/mismatched-files/lakeFS/docs/_site
+            while read -r line; do
+              file1=$(echo "$line" | cut -d' ' -f2)
+              file2=$(echo "$line" | cut -d' ' -f4)
+              cp "$file1" /tmp/mismatched-files/docs-lakeFS 
+              cp "$file2" /tmp/mismatched-files/lakeFS/docs/_site
+            done < diffs.txt            
+           
             exit 1
           fi
+
+      - name: Upload artifacts if mismatches found
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: mismatched-files
+          path: /tmp/mismatched-files/        

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -39,15 +39,29 @@ jobs:
         run: |
           diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
                   grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
-                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" > diffs.txt
-          diffs=$(wc -l < diffs.txt | tr -d '[:space:]')
-          if [ "$diffs" -ne 0 ]; then
+                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" > /tmp/diffs.txt
+
+          if [ -e "/tmp/diffs.txt" ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
             echo " "
-            cat diffs.txt
+            cat /tmp/diffs.txt
+
+            mkdir -p /tmp/mismatched-files/docs-lakeFS 
+            mkdir -p /tmp/mismatched-files/lakeFS/docs/_site
+            while read -r line; do
+              file1=$(echo "$line" | cut -d' ' -f2)
+              file2=$(echo "$line" | cut -d' ' -f4)
+              cp "$file1" /tmp/mismatched-files/docs-lakeFS 
+              cp "$file2" /tmp/mismatched-files/lakeFS/docs/_site
+            done < /tmp/diffs.txt
+
             exit 1
+          else
+            echo "✅ Docs match"
+            true
           fi
 
+          
       - name: Compare Generated Site 2
         run: |
           pwd

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -44,7 +44,7 @@ jobs:
                           -e ": CNAME" \
                           -e "Files docs-lakeFS/assets/js/search-data.json and lakeFS/docs/_site/assets/js/search-data.json differ" \
                           -e "Files docs-lakeFS/posts/index.html and lakeFS/docs/_site/posts/index.html differ" \
-                          -e ": CNAME" \
+                          -e "Files docs-lakeFS/redirects.json and lakeFS/docs/_site/redirects.json differ" \
                         > diffs.txt
           diff_ct=$(wc -l < diffs.txt | tr -d '[:space:]')
 

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -47,6 +47,8 @@ jobs:
                           -e "Files docs-lakeFS/redirects.json and lakeFS/docs/_site/redirects.json differ" \
                         > /tmp/diffs.txt
 
+          ls -l /tmp/diffs.txt
+
           if [ -e "/tmp/diffs.txt" ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
             echo " "
@@ -64,6 +66,7 @@ jobs:
             exit 1
           else
             echo "✅ Docs match"
+            true
           fi
 
       - name: Upload artifacts if mismatches found

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
                   grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
-                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" > /tmp/diffs.txt
+                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" -e "docs-lakeFS\/assets\/js\/search-data.json" -e "docs-lakeFS\/posts\/index.html" -e "docs-lakeFS\/redirects.json" > /tmp/diffs.txt
 
           if [ -e "/tmp/diffs.txt" ]; then
             echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
@@ -72,9 +72,9 @@ jobs:
           grep -v -e ": .git" \
                   -e ": versions.json" \
                   -e ": CNAME" \
-                  -e "Files docs-lakeFS/assets/js/search-data.json and lakeFS/docs/_site/assets/js/search-data.json differ" \
-                  -e "Files docs-lakeFS/posts/index.html and lakeFS/docs/_site/posts/index.html differ" \
-                  -e "Files docs-lakeFS/redirects.json and lakeFS/docs/_site/redirects.json differ" \
+                  -e "docs-lakeFS\/assets\/js\/search-data.json" \
+                  -e "docs-lakeFS\/posts\/index.html" \
+                  -e "docs-lakeFS\/redirects.json" \
                 > /tmp/diffs.txt
 
           pwd

--- a/.github/workflows/stale-docs-check.yml
+++ b/.github/workflows/stale-docs-check.yml
@@ -37,46 +37,14 @@ jobs:
   
       - name: Compare Generated Site 1
         run: |
+          pwd
           diff --brief --recursive docs-lakeFS lakeFS/docs/_site | \
                   grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' | \
-                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" -e "docs-lakeFS\/assets\/js\/search-data.json" -e "docs-lakeFS\/posts\/index.html" -e "docs-lakeFS\/redirects.json" > /tmp/diffs.txt
-
-          if [ -e "/tmp/diffs.txt" ]; then
-            echo "🚨 Docs published on docs.lakefs.io don't match docs generated from source 🚨"
-            echo " "
-            cat /tmp/diffs.txt
-
-            mkdir -p /tmp/mismatched-files/docs-lakeFS 
-            mkdir -p /tmp/mismatched-files/lakeFS/docs/_site
-            while read -r line; do
-              file1=$(echo "$line" | cut -d' ' -f2)
-              file2=$(echo "$line" | cut -d' ' -f4)
-              cp "$file1" /tmp/mismatched-files/docs-lakeFS 
-              cp "$file2" /tmp/mismatched-files/lakeFS/docs/_site
-            done < /tmp/diffs.txt
-
-            exit 1
-          else
-            echo "✅ Docs match"
-            true
-          fi
-
-          
-      - name: Compare Generated Site 2
-        run: |
+                  grep -v -e ": .git" -e ": versions.json" -e ": CNAME" > /tmp/diffs0.txt
           pwd
-          ls -l 
-          diff --brief --recursive docs-lakeFS lakeFS/docs/_site > /tmp/raw_diff.txt
-          pwd
-          grep -v --extended-regexp 'Only in docs-lakeFS: v?[[:digit:]]+(\.[[:digit:]]+)?' /tmp/raw_diff.txt | \
-          grep -v -e ": .git" \
-                  -e ": versions.json" \
-                  -e ": CNAME" \
-                  -e "docs-lakeFS\/assets\/js\/search-data.json" \
-                  -e "docs-lakeFS\/posts\/index.html" \
-                  -e "docs-lakeFS\/redirects.json" \
-                > /tmp/diffs.txt
-
+          grep -v -e "docs-lakeFS/assets/js/search-data.json" \
+                  -e "docs-lakeFS/posts/index.html" \
+                  -e "docs-lakeFS/redirects.json" /tmp/diffs0.txt > /tmp/diffs.txt
           pwd
 
           if [ -e "/tmp/diffs.txt" ]; then


### PR DESCRIPTION
This adds the feature to capture any files that are mis-matched as GitHub Action artefacts. 

It also excludes three files which are known to be different. I'm not sure *why* they are, but manually comparing them they have the same nett-content. 