### PR TITLE
Add a cookies scratchpad

### DIFF
--- a/unreachable/index.html
+++ b/unreachable/index.html
@@ -1,0 +1,10 @@
+<html>
+    <head>
+	<!-- Start of HubSpot Embed Code -->
+	<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/8040338.js"></script>
+	<!-- End of HubSpot Embed Code -->
+    </head>
+    <body>
+	<h1>The quick brown fox gets the attention of marketing!</h1>
+    </body>
+</html>


### PR DESCRIPTION
This page should _not_ be easy to find, it is not linked from anywhere.

It tests whether we can directly use a HubSpot consent banner to get cookies from HubSpot.

Will pull with first approval, lemme know if you want me to wait for the other reviewer.